### PR TITLE
Avoids unnecessary warnings

### DIFF
--- a/frontend/src/containers/MainLayout.js
+++ b/frontend/src/containers/MainLayout.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Link, withRouter } from 'react-router-dom';
 
+//eslint-disable-next-line
 import { Layout, Menu, Breadcrumb, Affix } from 'antd';
 import { connect } from 'react-redux';
 


### PR DESCRIPTION
Breadcrumb hasn't been used. So terminal would trigger with warnings.